### PR TITLE
Fix PHP 8.1 deprecation warning in HPackNative

### DIFF
--- a/src/Internal/HPackNative.php
+++ b/src/Internal/HPackNative.php
@@ -205,7 +205,7 @@ final class HPackNative
         $lookup = 0;
         $lengths = self::$huffmanLengths;
         $length = \strlen($input);
-        $out = \str_repeat("\0", $length / 5 * 8 + 1); // max length
+        $out = \str_repeat("\0", (int) \floor($length / 5 * 8 + 1)); // max length
 
         // Fail if EOS symbol is found.
         if (\strpos($input, "\x3f\xff\xff\xff") !== false) {


### PR DESCRIPTION
Fixes a deprecation warning that was introduced in PHP 8.1:

```
Deprecated: Implicit conversion from float #.# to int loses precision in HPackNative.php on line 208
```