### PR TITLE
Fix chr() deprecation warning in Huffman encoding 

### DIFF
--- a/src/Internal/HPackNative.php
+++ b/src/Internal/HPackNative.php
@@ -269,9 +269,10 @@ final class HPackNative
 
                 for ($byte = $bytes; $byte >= 0; $byte--) {
                     $codes[] = \chr(
-                        ($byte
-                            ? $bits >> ($length - ($bytes - $byte + 1) * 8 + $bit)
-                            : ($bits << ((0x30 - $length - $bit) & 7))
+                        (
+                            $byte
+                                ? $bits >> ($length - ($bytes - $byte + 1) * 8 + $bit)
+                                : ($bits << ((0x30 - $length - $bit) & 7))
                         ) & 0xFF
                     );
                 }

--- a/src/Internal/HPackNative.php
+++ b/src/Internal/HPackNative.php
@@ -269,9 +269,10 @@ final class HPackNative
 
                 for ($byte = $bytes; $byte >= 0; $byte--) {
                     $codes[] = \chr(
-                        $byte
+                        ($byte
                             ? $bits >> ($length - ($bytes - $byte + 1) * 8 + $bit)
                             : ($bits << ((0x30 - $length - $bit) & 7))
+                        ) & 0xFF
                     );
                 }
 

--- a/test/Internal/HPackNativeTest.php
+++ b/test/Internal/HPackNativeTest.php
@@ -10,4 +10,60 @@ class HPackNativeTest extends HPackTest
     {
         return new HPackNative;
     }
+
+    public function testHuffmanEncodeDoesNotTriggerChrDeprecation(): void
+    {
+        $deprecations = [];
+
+        \set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            \E_DEPRECATED
+        );
+
+        try {
+            $hpack = self::createInstance();
+
+            // Simple ASCII
+            $headers = [
+                ['x-test', 'hello world'],
+            ];
+
+            $encoded = $hpack->encode($headers);
+            self::assertSame($headers, $hpack->decode($encoded, 8192));
+
+            // Full byte range to exercise all Huffman codes
+            $headers = [
+                ['x-allbytes', \implode(\array_map('chr', \range(0, 255)))],
+            ];
+
+            $encoded = $hpack->encode($headers);
+            self::assertSame($headers, $hpack->decode($encoded, 8192));
+
+            // Long value to exercise multi-byte Huffman sequences
+            $headers = [
+                ['x-long', \str_repeat('abcdefghijklmnopqrstuvwxyz0123456789', 50)],
+            ];
+
+            $encoded = $hpack->encode($headers);
+            self::assertSame($headers, $hpack->decode($encoded, 8192));
+
+            // Multiple headers
+            $headers = [
+                [':method', 'GET'],
+                [':path', '/foo/bar?baz=1&qux=2'],
+                ['content-type', 'application/json'],
+                ['x-binary', "\x00\x01\x02\xff\xfe\xfd"],
+            ];
+
+            $encoded = $hpack->encode($headers);
+            self::assertSame($headers, $hpack->decode($encoded, 8192));
+        } finally {
+            \restore_error_handler();
+        }
+
+        self::assertEmpty($deprecations, 'chr() deprecation triggered: ' . \implode(', ', $deprecations));
+    }
 }


### PR DESCRIPTION
Mask bit-shift results with **& 0xFF** before passing to **chr()** in **huffmanCodesInit()**.
PHP 8.5 deprecated **chr()** with values outside 0-255. Added test covering the fix.